### PR TITLE
DRUD-521: Improve readinessProbe to detect sealed vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,4 +247,6 @@ value           	1
 * Restart/kill <vault-2*> or kill the process
 * <vault-1*> will become active
 
-Please note that when you do a `kubectl get po -l app=vault` you will only see one of the instances "ready". This is because only one can be leader, and that's the one that the load balancer wants to talk to by default. The readinessProbe on each determines whether it is the leader.
+Note that if a vault is sealed, its "READY" in `kubectl get po` will be 1/2, meaning
+that although the logger container is ready, the vault container is not - it's not
+considered ready until unsealed.

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -54,7 +54,8 @@ spec:
             value: http://localhost:9000
           readinessProbe:
             httpGet:
-              path: /v1/sys/health
+              # "leader" returns a 503 for a sealed vault, which is basically what we want
+              path: /v1/sys/leader
               port: 9000
             initialDelaySeconds: 30
             timeoutSeconds: 1

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -54,7 +54,8 @@ spec:
             value: http://localhost:9000
           readinessProbe:
             httpGet:
-              path: /v1/sys/health
+              # "leader" returns a 503 for a sealed vault, which is basically what we want
+              path: /v1/sys/leader
               port: 9000
             initialDelaySeconds: 30
             timeoutSeconds: 1


### PR DESCRIPTION
Changes the readinessProbe to /v1/sys/leader, which gives a 503 when vault is sealed, which is really the readiness issue we're concerned about. This should give us a genuine way to test whether an individual vault instance is functional.

The only downside I know of is that half of requests to the load balancer service will be forwarded by the standby vault server when everything is working right and both vaults are unsealed.