### PR TITLE
DRUD-523: Use local consul agent on vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ quote-escaping problems.
 3. Click "ACL"
 4. Add an ACL with name vault-token, type client, rules:
 ```
-key "vault/" {
-  policy = "write"
-}
+key "vault/" { policy = "write" },
+service "vault" {"policy"= "write"} 
+
 ```
 5. Capture the newly created vault-token and with it (example key here):
 ``` sh

--- a/deployments/consul-1.yaml
+++ b/deployments/consul-1.yaml
@@ -17,7 +17,7 @@ spec:
           image: "consul:0.7.2"
           resources:
             limits:
-              cpu: 300m
+              cpu: 200m
               memory: 200Mi
           args:
             - "agent"

--- a/deployments/consul-1.yaml
+++ b/deployments/consul-1.yaml
@@ -14,7 +14,11 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:0.7.1"
+          image: "consul:0.7.2"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 200Mi
           args:
             - "agent"
             - "-ui"
@@ -22,7 +26,6 @@ spec:
             - "-data-dir=/var/lib/consul"
             - "-server"
             - "-bootstrap-expect=3"
-            #- "-bind=0.0.0.0"
             - "-advertise=$(CONSUL_1_SERVICE_HOST)"
             - "-rejoin"
             - "-client=0.0.0.0"

--- a/deployments/consul-1.yaml
+++ b/deployments/consul-1.yaml
@@ -16,6 +16,9 @@ spec:
         - name: consul
           image: "consul:0.7.2"
           resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
             limits:
               cpu: 200m
               memory: 200Mi

--- a/deployments/consul-2.yaml
+++ b/deployments/consul-2.yaml
@@ -14,7 +14,11 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:0.7.1"
+          image: "consul:0.7.2"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 200Mi
           args:
             - "agent"
             - "-ui"
@@ -22,7 +26,6 @@ spec:
             - "-data-dir=/var/lib/consul"
             - "-server"
             - "-bootstrap-expect=3"
-            #- "-bind=0.0.0.0"
             - "-advertise=$(CONSUL_2_SERVICE_HOST)"
             - "-client=0.0.0.0"
             - "-rejoin"

--- a/deployments/consul-2.yaml
+++ b/deployments/consul-2.yaml
@@ -17,7 +17,7 @@ spec:
           image: "consul:0.7.2"
           resources:
             limits:
-              cpu: 300m
+              cpu: 200m
               memory: 200Mi
           args:
             - "agent"

--- a/deployments/consul-2.yaml
+++ b/deployments/consul-2.yaml
@@ -16,6 +16,9 @@ spec:
         - name: consul
           image: "consul:0.7.2"
           resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
             limits:
               cpu: 200m
               memory: 200Mi

--- a/deployments/consul-3.yaml
+++ b/deployments/consul-3.yaml
@@ -14,7 +14,11 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:0.7.1"
+          image: "consul:0.7.2"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 200Mi
           args:
             - "agent"
             - "-ui"

--- a/deployments/consul-3.yaml
+++ b/deployments/consul-3.yaml
@@ -17,7 +17,7 @@ spec:
           image: "consul:0.7.2"
           resources:
             limits:
-              cpu: 300m
+              cpu: 200m
               memory: 200Mi
           args:
             - "agent"

--- a/deployments/consul-3.yaml
+++ b/deployments/consul-3.yaml
@@ -16,6 +16,9 @@ spec:
         - name: consul
           image: "consul:0.7.2"
           resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
             limits:
               cpu: 200m
               memory: 200Mi

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -15,7 +15,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: vault
-          image: "drud/vault:0.6.3"
+          image: "drud/vault:0.6.3-2"
           resources:
             limits:
               cpu: 300m

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -37,7 +37,7 @@ spec:
                   address = "$(CONSUL_HTTP_SERVICE_HOST):$(CONSUL_HTTP_SERVICE_PORT)"
                   cluster_addr = "https://$(VAULT_1_SERVICE_HOST):$(VAULT_1_SERVICE_PORT_BACKENDPORT)"
                   token = "$VAULT_CONSUL_KEY"
-                  disable_registration = "true"
+                  check_timeout = "3s"
                 }
                 listener "tcp" {
                   address = "0.0.0.0:8200"

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -19,7 +19,8 @@ spec:
           resources:
             limits:
               cpu: 300m
-              memory: 200Mi
+              # Active vault leader has been seen with ~300MB
+              memory: 500Mi
           ports:
           - containerPort: 8200
             name: main-port

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -15,8 +15,11 @@ spec:
         fsGroup: 1000
       containers:
         - name: vault
-          image: "drud/vault:0.6.2"
-          imagePullPolicy: Always
+          image: "drud/vault:0.6.3"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 200Mi
           ports:
           - containerPort: 8200
             name: main-port

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -17,10 +17,14 @@ spec:
         - name: vault
           image: "drud/vault:0.6.3-2"
           resources:
+          resources:
+            requests:
+              cpu: 300m
+              memory: 700Mi
             limits:
               cpu: 300m
-              # Active vault leader has been seen with ~300MB
-              memory: 500Mi
+              # Active vault has been seen with 700Mi
+              memory: 1000Mi
           ports:
           - containerPort: 8200
             name: main-port

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -37,10 +37,10 @@ spec:
             # See https://github.com/hashicorp/vault/issues/1559 for why true is quoted in disable_registration
             value:
                 backend "consul" {
-                  address = "$(CONSUL_HTTP_SERVICE_HOST):$(CONSUL_HTTP_SERVICE_PORT)"
+                  address = "localhost:8500"
                   cluster_addr = "https://$(VAULT_1_SERVICE_HOST):$(VAULT_1_SERVICE_PORT_BACKENDPORT)"
                   token = "$VAULT_CONSUL_KEY"
-                  check_timeout = "3s"
+                  disable_registration = "true"
                 }
                 listener "tcp" {
                   address = "0.0.0.0:8200"
@@ -48,7 +48,7 @@ spec:
                   tls_key_file = "/etc/tls/tls.key"
                 }
                 listener "tcp" {
-                  address = "0.0.0.0:9000"
+                  address = "127.0.0.1:9000"
                   tls_disable = 1
                 }
                 disable_mlock = true
@@ -68,6 +68,21 @@ spec:
                 mountPath: /etc/tls
               - name: log-storage
                 mountPath: /vault/logs
+        - name: consul-agent-client
+          image: "consul:0.7.2"
+#          resources:
+#            limits:
+#              cpu: 100m
+#              memory: 200Mi
+          args:
+            - "agent"
+            - "-data-dir=/tmp/consul"
+            - "-retry-join=$(CONSUL_1_SERVICE_HOST)"
+            - "-config-dir=/etc/consul"
+            - "-node=vault-1"
+          volumeMounts:
+            - name: "consulconfig"
+              mountPath: /etc/consul
         - name: logging-sidecar
           image: drud/fluentd_logging_sidecar:1.4
           resources:
@@ -90,5 +105,9 @@ spec:
           }
         - name: log-storage
           emptyDir: {}
+        - name: "consulconfig"
+          "secret": {
+            "secretName": "consul-config"
+          }
 
 ---

--- a/deployments/vault-1.yaml
+++ b/deployments/vault-1.yaml
@@ -25,6 +25,8 @@ spec:
             name: main-port
           - containerPort: 8201
             name: local-talk-port
+          - containerPort: 9000
+            name: monitor-port
           env:
           - name: VAULT_CONSUL_KEY
             valueFrom:
@@ -48,7 +50,7 @@ spec:
                   tls_key_file = "/etc/tls/tls.key"
                 }
                 listener "tcp" {
-                  address = "127.0.0.1:9000"
+                  address = "0.0.0.0:9000"
                   tls_disable = 1
                 }
                 disable_mlock = true

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -15,7 +15,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: vault
-          image: "drud/vault:0.6.3"
+          image: "drud/vault:0.6.3-2"
           resources:
             limits:
               cpu: 300m

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -36,8 +36,8 @@ spec:
                 backend "consul" {
                   address = "$(CONSUL_HTTP_SERVICE_HOST):$(CONSUL_HTTP_SERVICE_PORT)"
                   cluster_addr = "https://$(VAULT_2_SERVICE_HOST):$(VAULT_2_SERVICE_PORT_BACKENDPORT)"
-                  disable_registration = "true"
                   token = "$VAULT_CONSUL_KEY"
+                  check_timeout = "3s"
                 }
                 listener "tcp" {
                   address = "0.0.0.0:8200"

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -37,10 +37,10 @@ spec:
             # See https://github.com/hashicorp/vault/issues/1559 for why true is quoted in disable_registration
             value:
                 backend "consul" {
-                  address = "$(CONSUL_HTTP_SERVICE_HOST):$(CONSUL_HTTP_SERVICE_PORT)"
+                  address = "localhost:8500"
                   cluster_addr = "https://$(VAULT_2_SERVICE_HOST):$(VAULT_2_SERVICE_PORT_BACKENDPORT)"
+                  disable_registration = "true"
                   token = "$VAULT_CONSUL_KEY"
-                  check_timeout = "3s"
                 }
                 listener "tcp" {
                   address = "0.0.0.0:8200"
@@ -48,7 +48,7 @@ spec:
                   tls_key_file = "/etc/tls/tls.key"
                 }
                 listener "tcp" {
-                  address = "0.0.0.0:9000"
+                  address = "127.0.0.1:9000"
                   tls_disable = 1
                 }
                 disable_mlock = true
@@ -68,6 +68,23 @@ spec:
                 mountPath: /etc/tls
               - name: log-storage
                 mountPath: /vault/logs
+              - name: "consulconfig"
+                mountPath: /etc/consul
+        - name: consul-agent-client
+          image: "consul:0.7.2"
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+          args:
+            - "agent"
+            - "-data-dir=/tmp/consul"
+            - "-retry-join=$(CONSUL_1_SERVICE_HOST)"
+            - "-config-dir=/etc/consul"
+            - "-node=vault-2"
+          volumeMounts:
+            - name: "consulconfig"
+              mountPath: /etc/consul
         - name: logging-sidecar
           image: drud/fluentd_logging_sidecar:1.4
           resources:
@@ -90,4 +107,7 @@ spec:
           }
         - name: log-storage
           emptyDir: {}
-
+        - name: "consulconfig"
+          "secret": {
+            "secretName": "consul-config"
+          }

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -19,7 +19,7 @@ spec:
           resources:
             limits:
               cpu: 300m
-              memory: 200Mi
+              memory: 500Mi
           ports:
           - containerPort: 8200
             name: main-port

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -15,8 +15,11 @@ spec:
         fsGroup: 1000
       containers:
         - name: vault
-          image: "drud/vault:0.6.2"
-          imagePullPolicy: Always
+          image: "drud/vault:0.6.3"
+          resources:
+            limits:
+              cpu: 300m
+              memory: 200Mi
           ports:
           - containerPort: 8200
             name: main-port

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -25,6 +25,8 @@ spec:
             name: main-port
           - containerPort: 8201
             name: local-talk-port
+          - containerPort: 9000
+            name: monitor-port
           env:
           - name: VAULT_CONSUL_KEY
             valueFrom:
@@ -48,7 +50,7 @@ spec:
                   tls_key_file = "/etc/tls/tls.key"
                 }
                 listener "tcp" {
-                  address = "127.0.0.1:9000"
+                  address = "0.0.0.0:9000"
                   tls_disable = 1
                 }
                 disable_mlock = true

--- a/deployments/vault-2.yaml
+++ b/deployments/vault-2.yaml
@@ -17,9 +17,12 @@ spec:
         - name: vault
           image: "drud/vault:0.6.3-2"
           resources:
+            requests:
+              cpu: 300m
+              memory: 700Mi
             limits:
               cpu: 300m
-              memory: 500Mi
+              memory: 1000Mi
           ports:
           - containerPort: 8200
             name: main-port

--- a/vaultimage/Dockerfile
+++ b/vaultimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM vault:0.6.2
+FROM vault:0.6.3
 MAINTAINER Randy Fay <rfay@newmediadenver.com>
 
 # Provide for envsubst from gettext


### PR DESCRIPTION
From reading the vault mailing list it appears that the "normal" deployment of vault has a local consul agent (not server). This has been highly recommended by hashicorp representatives, so this attempts to implement that, and also upgrades vault and consul to current versions.

* Upgrade consul to 0.7.2
* Upgrade vault to 0.6.3
* Add resource stanza to each component
* Add consul local agent to vault pod and change vault to use local agent

Due to a mistake made in testing, the vault deployments are already running on prod, but the consul deployments (only slight change) are not yet there.
