### PR TITLE
Add standard github templates from ddev

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What happened (or feature request):
+
+
+## What you expected to happen:
+
+
+## How to reproduce it (as minimally and precisely as possible):
+
+
+## Anything else do we need to know:
+
+
+## Related source links or issues:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## The Problem:
+
+## The Fix:
+
+## The Test:
+
+## Automation Overview:
+<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
+
+## Related Issue Link(s):
+
+## Release/Deployment notes:
+<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
+


### PR DESCRIPTION
## The Problem:

We're getting a variety of issues from people who are using this. It will be good to standardize issues a bit more.

## The Fix:

Bring github templates in from ddev.

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

This changes nothing but our user experience creating issues and PRs.
