### PR TITLE
Move to Persistent Volumes (fixes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ load-balancer service via https.
 ### Create Volumes
 
 ``` sh
-$ gcloud compute disks create --size=50GB consul-1 consul-2 consul-3
+$ kubectl apply -f ./pv
 ```
 
 ### Create consul-config secret for consul configuration

--- a/deployments/consul-1.yaml
+++ b/deployments/consul-1.yaml
@@ -66,9 +66,8 @@ spec:
 
       volumes:
         - name: data
-          gcePersistentDisk:
-            pdName: consul-1
-            fsType: ext4
+          persistentVolumeClaim:
+            claimName: consul-1
         - name: "consulconfig"
           "secret": {
             "secretName": "consul-config"

--- a/deployments/consul-2.yaml
+++ b/deployments/consul-2.yaml
@@ -66,9 +66,8 @@ spec:
               mountPath: /etc/consul
       volumes:
         - name: data
-          gcePersistentDisk:
-            pdName: consul-2
-            fsType: ext4
+          persistentVolumeClaim:
+            claimName: consul-2
         - name: "consulconfig"
           "secret": {
             "secretName": "consul-config"

--- a/deployments/consul-3.yaml
+++ b/deployments/consul-3.yaml
@@ -68,9 +68,8 @@ spec:
 
       volumes:
         - name: data
-          gcePersistentDisk:
-            pdName: consul-3
-            fsType: ext4
+          persistentVolumeClaim:
+            claimName: consul-3
         - name: "consulconfig"
           "secret": {
             "secretName": "consul-config"

--- a/pv/consul-1.yaml
+++ b/pv/consul-1.yaml
@@ -1,0 +1,13 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: consul-1
+  annotations:
+    volume.beta.kubernetes.io/storage-class: default
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 50Gi

--- a/pv/consul-2.yaml
+++ b/pv/consul-2.yaml
@@ -1,0 +1,13 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: consul-2
+  annotations:
+    volume.beta.kubernetes.io/storage-class: default
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 50Gi

--- a/pv/consul-3.yaml
+++ b/pv/consul-3.yaml
@@ -1,0 +1,13 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: consul-3
+  annotations:
+    volume.beta.kubernetes.io/storage-class: default
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 50Gi


### PR DESCRIPTION
Instead of the gcloud command, use PersistentVolumeClaims to create the consul volumes

## The Problem:
Currently, this is very specific to glcoud and by moving to PVC's it will work on minikube, aws and other k8s cluster types

## The Fix:
Move from the glcoud command to PVC

## Related Issue Link(s):
#14 

## Release/Deployment notes:
This will only affect existing users if they try and re-deploy the consul deployments, new users will be fine.
