### PR TITLE
update consul to 0.8.2 and add new session acl for vault in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ quote-escaping problems.
 4. Add an ACL with name vault-token, type client, rules:
 ```
 key "vault/" { policy = "write" },
-service "vault" {"policy"= "write"} 
-
+service "vault" { policy = "write" }
+session "vault" { policy = "write" }
 ```
 5. Capture the newly created vault-token and with it (example key here):
 ``` sh

--- a/deployments/consul-1.yaml
+++ b/deployments/consul-1.yaml
@@ -14,7 +14,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:0.7.2"
+          image: "consul:0.8.2"
           resources:
             requests:
               cpu: 100m

--- a/deployments/consul-2.yaml
+++ b/deployments/consul-2.yaml
@@ -14,7 +14,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:0.7.2"
+          image: "consul:0.8.2"
           resources:
             requests:
               cpu: 100m

--- a/deployments/consul-3.yaml
+++ b/deployments/consul-3.yaml
@@ -14,7 +14,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: consul
-          image: "consul:0.7.2"
+          image: "consul:0.8.2"
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## The Problem:

Consul 0.8 has been released. The repo currently references Consul 0.7

## The Fix:

Update the Consul image appropriately, and add a new ACL for vault session

## The Test:

Have tested locally by following instructions in my local minikube cluster. I will push a separate branch for the minikube-related changes.

## Automation Overview:

No tests are needed because the original repo does not provide an automated test harness.

## Related Issue Link(s):

## Release/Deployment notes:


